### PR TITLE
Update rxjs dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "core-js": "2.4.1",
     "crypto-js": "3.1.9-1",
     "lodash": "4.17.4",
-    "rxjs": "5.2.0"
+    "rxjs": "^5.0.0"
   },
   "devDependencies": {
     "@types/jquery": "2.0.41",
@@ -38,8 +38,8 @@
     "@types/microsoftteams": "1.0.0",
     "@types/office-js": "^0.0.42",
     "browserify": "14.1.0",
-    "npm-run-all": "4.0.2",
     "dts-builder": "1.1.0",
+    "npm-run-all": "4.0.2",
     "rimraf": "2.6.1",
     "tslint": "4.5.1",
     "typescript": "2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1257,9 +1257,9 @@ ripemd160@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-1.0.1.tgz#93a4bbd4942bc574b69a8fa57c71de10ecca7d6e"
 
-rxjs@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.2.0.tgz#db537de8767c05fa73721587a29e0085307d318b"
+rxjs@^5.0.0:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.4.2.tgz#2a3236fcbf03df57bae06fd6972fd99e5c08fcf7"
   dependencies:
     symbol-observable "^1.0.1"
 


### PR DESCRIPTION
As a helper library adding a non-trivial dependency into consuming projects, I think it make sense to be as liberal with the version range as possible.  Meaning, it seems like this package should specify the minimum version that will work with `office-js-helpers`.  

This would mean that apps using it which are depending on (and perhaps locked with `yarn.lock` or `package.lock`) for example version `5.1.0` shouldn't necessarily need to also ship version `5.4.2` to all of their users just because of a mismatch with this helper library.  As an example, this PR saves 7.88kb in my own project.  Which granted isn't huge, but it's not nothing either, and slow load times in task panes is _the worst_. :)

From what I can tell, this package is just using a pretty vanilla observable and doesn't seem to be doing anything too crazy with it, so this PR just specifies that `rxjs: ^5.0.0` should be installed, while still updating the `yarn.lock` file so that developers working on this project get the latest version.

What do you think?