### PR TITLE
Use modular lodash dependencies

### DIFF
--- a/src/helpers/storage.ts
+++ b/src/helpers/storage.ts
@@ -1,6 +1,6 @@
 /* Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. */
 
-import debounce = require('lodash/debounce');
+import debounce from 'lodash/debounce';
 import { Dictionary } from './dictionary';
 import * as md5 from 'crypto-js/md5';
 import { Observable } from 'rxjs/Observable';

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -1,6 +1,8 @@
 /* Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. */
 
-import { isString, isError, isObject } from 'lodash';
+import isString from 'lodash/isstring';
+import isError from 'lodash/iserror';
+import isObject from 'lodash/isobject';
 import { CustomError } from '../errors/custom.error';
 import { Utilities, PlatformType } from '../helpers/utilities';
 


### PR DESCRIPTION
I was taking a look at the production bundle of my add-in, and noticed that I was including all 74kb of lodash in it, even though I don't use lodash.  I found that it was because of this package, and the way that it was importing from lodash.  

This PR changes office-js-helpers to depend on only the small functions that are actually being used, dropping the total size down to just over 2kb.  This is a pretty significant potential savings for any add-ins that use this helper library.