### PR TITLE
fix dialog not returning an error when the user cancel or did not grant pe

### DIFF
--- a/src/helpers/dialog.ts
+++ b/src/helpers/dialog.ts
@@ -87,7 +87,7 @@ export class Dialog<T> {
     return new Promise((resolve, reject) => {
       Office.context.ui.displayDialogAsync(this.url, { width: this.size.width$, height: this.size.height$ }, (result: Office.AsyncResult) => {
         if (result.status === Office.AsyncResultStatus.Failed) {
-          throw new DialogError(result.error.message, result.error);
+		  reject(new DialogError(result.error.message, result.error));
         }
         else {
           let dialog = result.value as Office.DialogHandler;


### PR DESCRIPTION
This will fix the dialog not returning an error when the user cancel or did not grant a permission to user the dialog api.

`authenticator
    .authenticate('name of endpoint', true /* force re-authentication */)
    .then(function(token) {
    /*
        `token` is newly obtained.
    */
    })
    .catch(e=>{
   /*
    This will work when user cancel the permission
   */
});`