### PR TITLE
Fixed the storage container name for the TokenStorage

### DIFF
--- a/src/authentication/token.manager.ts
+++ b/src/authentication/token.manager.ts
@@ -33,7 +33,7 @@ export class TokenStorage extends Storage<IToken> {
    * @constructor
   */
   constructor(storageType = StorageType.LocalStorage) {
-    super('OAuth2Endpoints', storageType);
+    super('OAuth2Tokens', storageType);
   }
 
   /**


### PR DESCRIPTION
Hello!

Looks like after some recent changes the container name for `TokenStorage` class has been changed to `OAuth2Endpoints` which is the same as for `EndpointsStorage`. This results in a very strange behavior of the library. Looking at the previous code I guess the correct name for the container for `TokenStorage` is `OAuth2Tokens`. 

So I've updated it.

Thanks! 