### PR TITLE
Fixed TS 2.8 namespace default export error

### DIFF
--- a/src/helpers/dialog.ts
+++ b/src/helpers/dialog.ts
@@ -87,7 +87,7 @@ export class Dialog<T> {
     return new Promise((resolve, reject) => {
       Office.context.ui.displayDialogAsync(this.url, { width: this.size.width$, height: this.size.height$ }, (result: Office.AsyncResult) => {
         if (result.status === Office.AsyncResultStatus.Failed) {
-		  reject(new DialogError(result.error.message, result.error));
+          reject(new DialogError(result.error.message, result.error));
         }
         else {
           let dialog = result.value as Office.DialogHandler;

--- a/src/ui/ui.spec.ts
+++ b/src/ui/ui.spec.ts
@@ -1,5 +1,5 @@
 import { _parseNotificationParams as pnp } from './ui';
-import stringify from '../util/stringify';
+import { stringify } from '../util/stringify';
 
 describe('_parseNotificationParams', () => {
   it('returns null if given nothing', () => {

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -1,7 +1,7 @@
 /* Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. */
 
 import { Utilities, PlatformType } from '../helpers/utilities';
-import stringify from '../util/stringify';
+import { stringify } from '../util/stringify';
 import html from './message-banner.html';
 
 const DEFAULT_WHITESPACE = 2;

--- a/src/util/stringify.ts
+++ b/src/util/stringify.ts
@@ -1,4 +1,4 @@
-export default function stringify(value: any): string {
+export function stringify(value: any): string {
   // JSON.stringify of undefined will return undefined rather than 'undefined'
   if (value === undefined) {
     return 'undefined';


### PR DESCRIPTION
Typescript 2.8 errors when trying to export a default from a `namespace`. Exploring the impact of moving completely away from namespaces and into module might take reaching out to a few people, so I figured a solid quick fix would be to simply move the default export to a named export.

Fixes #82 
Fixes #79 