### PR TITLE
Fixes issue 102

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ authenticator
     .catch(OfficeHelpers.Utilities.log);
 
 // get the cached token if any. returns null otherwise.
-var token = authenticator.tokens.get('name of endpoint');
+var token = authenticator.tokens.getValidToken('name of endpoint');
 ```
 If a cached token expires, then the dialog is automatically launched to re-authenticate the user.
 > Note on Refresh Tokens: By default, Implicit OAuth does not support Token Refresh as a security measure. This is because Access Tokens cannot be securely stored inside of a JavaScript client.

--- a/src/authentication/token.manager.ts
+++ b/src/authentication/token.manager.ts
@@ -70,7 +70,7 @@ export class TokenStorage extends Storage<IToken> {
    * @param {string} provider Unique name of the corresponding OAuth Token.
    * @return {object} Returns the token or null if its either expired or doesn't exist.
    */
-  get(provider: string): IToken {
+  getValidToken(provider: string): IToken {
     let token = super.get(provider);
     if (token == null) {
       return token;


### PR DESCRIPTION
In IE or the outlook desktop the token can be deleted if the token is expired. The get method to get the token actual token without the expire check is over written, therefore the calls to the get method that checks to the token to be expired is being called in the delete method and the infinite loop is created.