### PR TITLE
Fix `get` token recursion issue on TokenStorage for expired tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/jest": "22.1.3",
     "@types/lodash": "4.14.104",
     "@types/node": "9.4.6",
+    "@types/tapable": "^0.2.5",
     "@types/webpack": "3.8.8",
     "awesome-typescript-loader": "3.4.1",
     "babel-core": "6.26.0",

--- a/src/authentication/authenticator.ts
+++ b/src/authentication/authenticator.ts
@@ -67,6 +67,10 @@ export class Authenticator {
       return Promise.resolve(token);
     }
 
+    if (hasTokenExpired) {
+      this.tokens.delete(provider);
+    }
+
     return this._openAuthDialog(provider, useMicrosoftTeams);
   }
 

--- a/src/authentication/authenticator.ts
+++ b/src/authentication/authenticator.ts
@@ -67,7 +67,7 @@ export class Authenticator {
       return Promise.resolve(token);
     }
 
-    if (hasTokenExpired) {
+    if (token && hasTokenExpired) {
       this.tokens.delete(provider);
     }
 

--- a/src/authentication/token.manager.ts
+++ b/src/authentication/token.manager.ts
@@ -64,29 +64,6 @@ export class TokenStorage extends Storage<IToken> {
   }
 
   /**
-   * Extends Storage's default get method
-   * Gets an OAuth Token after checking its expiry
-   *
-   * @param {string} provider Unique name of the corresponding OAuth Token.
-   * @return {object} Returns the token or null if its either expired or doesn't exist.
-   */
-  get(provider: string): IToken {
-    let token = super.get(provider);
-    if (token == null) {
-      return token;
-    }
-
-    let expired = TokenStorage.hasExpired(token);
-    if (expired) {
-      super.delete(provider);
-      return null;
-    }
-    else {
-      return token;
-    }
-  }
-
-  /**
    * Extends Storage's default add method
    * Adds a new OAuth Token after settings its expiry
    *

--- a/src/authentication/token.spec.ts
+++ b/src/authentication/token.spec.ts
@@ -1,0 +1,43 @@
+import { TokenStorage, IToken } from './token.manager';
+
+describe('The TokenStorage class', () => {
+  it('can be instantiated', () => {
+    // Setup
+    const tokenStorage = new TokenStorage();
+
+    // Assert
+    expect(tokenStorage).toBeDefined();
+  });
+
+  it('can get a token that has not expired', () => {
+    // Setup
+    const tokenStorage = new TokenStorage();
+    const mockToken: IToken = {
+      provider: 'mockProvider',
+      expires_at: new Date(Date.now() + 3 * 60 * 60 * 1000)
+    };
+    const mockTokenName = 'mockTokenName';
+
+    // Act
+    tokenStorage.set(mockTokenName, mockToken);
+
+    // Assert
+    expect(tokenStorage.get(mockTokenName)).toEqual(mockToken);
+  });
+
+  it('can get a token that has expired', () => {
+    // Setup
+    const tokenStorage = new TokenStorage();
+    const mockToken: IToken = {
+      provider: 'mockProvider',
+      expires_at: new Date(Date.now() - 3 * 60 * 60 * 1000)
+    };
+    const mockTokenName = 'mockTokenName';
+
+    // Act
+    tokenStorage.set(mockTokenName, mockToken);
+
+    // Assert
+    expect(tokenStorage.get(mockTokenName)).toEqual(mockToken);
+  });
+});

--- a/src/helpers/storage.ts
+++ b/src/helpers/storage.ts
@@ -5,7 +5,7 @@ import { Observable } from 'rxjs/Observable';
 import { Exception } from '../errors/exception';
 
 const NOTIFICATION_DEBOUNCE = 300;
-const DATE_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/;
 
 export enum StorageType {
   LocalStorage,
@@ -248,7 +248,7 @@ export class Storage<T> {
 
   /**
    * Determine if the value was a Date type and if so return a Date object instead.
-   * https://blog.mariusschulz.com/2016/04/28/deserializing-json-strings-as-javascript-date-objects
+   * Regex matches an ISO date string.
    */
   private _reviver(_key: string, value: any) {
     if (isString(value) && DATE_REGEX.test(value)) {


### PR DESCRIPTION
This PR addresses issues #102 and #76 and it represents an alternative solution to PR #106.

When calling [`get`](https://github.com/OfficeDev/office-js-helpers/blob/master/src/authentication/token.manager.ts#L73) on the TokenStorage class the method checks to see whether the token has expired. If the token has expired it calls [`super.delete(tokenKey)`](https://github.com/OfficeDev/office-js-helpers/blob/master/src/authentication/token.manager.ts#L81) which lives on the parent Storage class. The Storage class delete method calls [`this.get(tokenKey)`](https://github.com/OfficeDev/office-js-helpers/blob/master/src/helpers/storage.ts#L125). Since `this` in this case is the TokenStorage class we get an infinite recursion.

I don't believe it's good practice to delete the expired token within the `get` method of the TokenStorage class since it's a side effect. If the token is expired then subsequent actions should be left to the caller. The authenticator appears to be the only caller of this method within the library and so I've updated that code to delete expired tokens if necessary. I'm aware this is a public method on TokenStorage and I'm open to suggestions about other possible alterations if this represents a breaking change for end users. However - it appears that the check for an expired token is the only additional functionality TokenStorage provides and since it does that in a way that fundamentally does not work I suspect this is a net gain.

I've added tests for the change.

I've also updated the typings for tapable as per the recommendations here: https://github.com/webpack/tapable/issues/53. A new install of this project otherwise throws errors.

Finally, my tests revealed that the reviver deserializer in the Storage class relies on an outdated REGEX matcher for ISO strings. I've updated that as well.

Thanks for your help and let me know if you have any questions.