### PR TITLE
In the implementation of Storage.has(key), we should check against null instead of undefined to see if a key exists in the storage.

### DIFF
--- a/src/helpers/storage.ts
+++ b/src/helpers/storage.ts
@@ -150,7 +150,7 @@ export class Storage<T> {
    */
   has(key: string): boolean {
     this._validateKey(key);
-    return this.get(key) !== undefined;
+    return this.get(key) !== null;
   }
 
   /**


### PR DESCRIPTION
According to the W3C standard (https://www.w3.org/TR/webstorage/#dom-storage-getitem):
> ... If the given key does not exist in the list associated with the object then this method must return **null**.

In the existing code, `this.get(key) !== undefined` would always be `true` even when the key doesn't exist. In this case, `this.get(key)` actually returns **`null`**.

This incorrect behavior is also impacting things like `authenticator.endpoints.has(...)`, which always mistakenly returns `true` for an actually not registered endpoint.