### PR TITLE
Using localForage (indexedDB) instead of localStorage for Edge

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/microsoftteams": "^1.2.1",
     "@types/office-js": "^0.0.51",
     "core-js": "^2.5.3",
+    "localforage": "^1.7.3",
     "lodash-es": "^4.17.5",
     "rxjs": "^5.5.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2219,6 +2219,11 @@ ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
+
 import-local@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"
@@ -3050,6 +3055,13 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lie@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
+  integrity sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=
+  dependencies:
+    immediate "~3.0.5"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -3080,6 +3092,13 @@ loader-utils@^1.0.2, loader-utils@^1.1.0:
     big.js "^3.1.3"
     emojis-list "^2.0.0"
     json5 "^0.5.0"
+
+localforage@^1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.7.3.tgz#0082b3ca9734679e1bd534995bdd3b24cf10f204"
+  integrity sha512-1TulyYfc4udS7ECSBT2vwJksWbkwwTX8BzeUIiq8Y07Riy7bDAAnxDaPU/tWyOVmQAcWJIEIFP9lPfBGqVoPgQ==
+  dependencies:
+    lie "3.1.1"
 
 locate-path@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixes #131 :
> Using this helper for authentication in Edge, the authentication window doesn't close (it works for Chrome and IE etc). The workaround that was put in place (using a polling mechanism on "storage") to circumvent issues with postMessage doesn't work anymore in Edge. For some reason, adding the information to localStorage in the popup window doesn't make it available in the main/opener Window of Edge.
> 
> I have seen this behaviour with
> 
> ```
> Microsoft Edge 44.17763.1.0
> Microsoft EdgeHTML 18.17763
> ```
> 
> I fixed this by using IndexedDB instead of localStorage in the workaround, using localForage wrapper. Using localForage minimizes impact on the code base since it exposes IndexedDB with an API similar to localStorage.
> **Known Issue:** IndexedDB is not available in Incognito Mode of Edge, which makes localForage fall back to localStorage and there the issue remains.
> 
> Not sure who owns this anymore, since a lot of necessary pull requests just don't get merged lately, so I'm tagging all: @casieber, @Zlatkovsky, @sumurthy & @LouMM
