### PR TITLE
Fix for isAddin returning true while in browser

### DIFF
--- a/src/helpers/utilities.ts
+++ b/src/helpers/utilities.ts
@@ -177,7 +177,7 @@ export class Utilities {
    * Utility to check if the code is running inside of an add-in.
    */
   static get isAddin() {
-    return Utilities.host !== HostType.WEB;
+    return !!Utilities.host && Utilities.host !== HostType.WEB;
   }
 
   /**


### PR DESCRIPTION
This fixes #133 :
> In a browser the Utilities.isAddin check return true, even when using it outside of Office. This results in the helpers trying to use the Dialog framework to open an authentication window instead of a normal browser popup.
> 
> Problematic code:
> https://github.com/OfficeDev/office-js-helpers/blob/a7b02821b9ffc9a5d89efaaa2d8f8de701524dc2/src/helpers/utilities.ts#L180
> 
> When used in the browser, the `host` property is undefined. This doesn't equal WEB and therefor it is considered being in an AddIn.
> 
> Not sure who owns this anymore, so I'm tagging all: @casieber, @Zlatkovsky, @sumurthy & @LouMM