### PR TITLE
Replaced ES6 Shim link

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Ensure that the Office.js file is loaded inside of your `.html` page using:
 <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"></script>
 
 <!-- ES6 Shim of your choice -->
-<script src="https://unpkg.com/core-js/client/core.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/es6-shim/0.35.5/es6-shim.min.js"></script>
 ```
 
 Then reference the helpers library using one of the following:


### PR DESCRIPTION
The current ES6 Shim link is not working, so I am replacing it with the most popular shim link,

Alternative link - https://unpkg.com/es6-shim@0.35.4/es6-shim.min.js